### PR TITLE
Moved RLlib-specific '__all__' key from general wrappers to RLlib-specific wrapper

### DIFF
--- a/CybORG/Agents/Wrappers/BlueFixedActionWrapper.py
+++ b/CybORG/Agents/Wrappers/BlueFixedActionWrapper.py
@@ -174,10 +174,7 @@ class BlueFixedActionWrapper(BaseWrapper):
         }
 
         terminated = {agent: done for agent, done in dones.items() if "blue" in agent}
-        terminated["__all__"] = False
-
         truncated = {agent: done for agent, done in dones.items() if "blue" in agent}
-        truncated["__all__"] = self.env.environment_controller.determine_done()
 
         info = {
             a: {"action_mask": self._action_space[a]["mask"]}

--- a/CybORG/Agents/Wrappers/EnterpriseMAE.py
+++ b/CybORG/Agents/Wrappers/EnterpriseMAE.py
@@ -13,7 +13,7 @@ class EnterpriseMAE(BlueEnterpriseWrapper, MultiAgentEnv):
     Creates a vector output for a neural network by directly pulling
     information out of the state object.
     """
-    
+
     def step(
         self,
         action_dict: dict[str, Any] | None = None,
@@ -64,6 +64,9 @@ class EnterpriseMAE(BlueEnterpriseWrapper, MultiAgentEnv):
 
             info (dict[str, dict]): Forwarded from BlueFixedActionWrapper.
         """
-        return super(BlueEnterpriseWrapper, self).step(
+        obs, rew, terminated, truncated, info = super(BlueEnterpriseWrapper, self).step(
             actions=action_dict, messages=messages
         )
+        terminated["__all__"] = False
+        truncated["__all__"] = self.env.environment_controller.determine_done()
+        return obs, rew, terminated, truncated, info


### PR DESCRIPTION
RLlib requires the terminated / truncated dictionaries to contain an '__all__' key, however, PettingZoo treats this as another agent and throws a warning. While this does not appear to affect training in any way from our tests, it is RLlib-specific, so it makes more sense to limit it to RLlib wrappers.

TrainingSB3 now runs without any warnings. On the other hand, TrainingRay is currently throwing some warnings, but I am not familiar with the library, so help would be greatly appreciated in addressing these if necessary.

Closes #12.