### PR TITLE
Fix Allow/Block Traffic Zone in `BlueFixedActionWrapper` and block status in observation from `BlueFlatWrapper`

### DIFF
--- a/CybORG/Agents/Wrappers/BlueFixedActionWrapper.py
+++ b/CybORG/Agents/Wrappers/BlueFixedActionWrapper.py
@@ -268,17 +268,18 @@ class BlueFixedActionWrapper(BaseWrapper):
                 continue
 
             if command_name in ("AllowTrafficZone", "BlockTrafficZone"):
-                for subnet in self._agent_metadata[agent_name]["subnets"]:
-                    dst = state.subnet_name_to_cidr[subnet]
+                for dstname in self._agent_metadata[agent_name]["subnets"]:
+                    dst = state.subnet_name_to_cidr[dstname]
 
                     for srcname, src in sorted_subnet_name_to_cidr:
+                        srcname = srcname.lower()
                         if src == dst:
                             continue
                         actions.append(
-                            command(from_subnet=src, to_subnet=dst, **action_params)
+                            command(from_subnet=srcname, to_subnet=dstname, **action_params)
                         )
                         labels.append(
-                            f"{command_name} {subnet} ({dst}) <- {srcname.lower()} ({src})"
+                            f"{command_name} {dstname} ({dst}) <- {srcname} ({src})"
                         )
                         mask.append(True)
                 continue

--- a/CybORG/Agents/Wrappers/BlueFlatWrapper.py
+++ b/CybORG/Agents/Wrappers/BlueFlatWrapper.py
@@ -202,9 +202,8 @@ class BlueFlatWrapper(BlueFixedActionWrapper):
             subnet_subvector = [subnet == name for name in subnet_names]
 
             # Get blocklist
-            cidr = state.subnet_name_to_cidr[subnet]
-            blocked_subnets = state.blocks.get(cidr, [])
-            blocked_subvector = [s in blocked_subnets for s in subnet_cidrs]
+            blocked_subnets = state.blocks.get(subnet, [])
+            blocked_subvector = [s in blocked_subnets for s in subnet_names]
 
             # Comms
             comms_policy = self.comms_policies[state.mission_phase]

--- a/CybORG/Tests/test_cc4/test_BlueEnterpriseWrapper.py
+++ b/CybORG/Tests/test_cc4/test_BlueEnterpriseWrapper.py
@@ -221,10 +221,10 @@ def blue_subnet(cyborg, blue_agent_short):
 def cyborg_blocked(cyborg, blue_subnet):
     """Here we choose a random subnet different to that of the blue agent being tested and add it to the blocklist"""
     state = cyborg.get_attr("environment_controller").state
-    other_subnets = [x for x in state.subnets if x!= blue_subnet]
-    blocked_subnet = random.choice(other_subnets)
-    state.blocks[blue_subnet] = [blocked_subnet]
-
+    other_subnets = [x.lower() for x in state.subnet_name_to_cidr if x != blue_subnet]
+    blocked_subnet_name = random.choice(other_subnets)
+    blue_subnet_name = state.subnets_cidr_to_name[blue_subnet]
+    state.blocks[blue_subnet_name] = [blocked_subnet_name]
     return cyborg
 
 @pytest.fixture
@@ -242,8 +242,8 @@ def test_BlueEnterpriseWrapper_blocked_step(cyborg_blocked, blue_agent_short, bl
     '''Manually block several hosts and check observation contains them'''
     state = cyborg_blocked.get_attr("environment_controller").state
     subnet_names = sorted([k.lower() for k in state.subnet_name_to_cidr])
-    blocked_subnet_address = state.blocks[blue_subnet][0]
-    blocked_subnet_name = state.subnets[blocked_subnet_address].name
+    blue_subnet_name = state.subnets_cidr_to_name[blue_subnet]
+    blocked_subnet_name = state.blocks[blue_subnet_name][0]
     blocked_index = subnet_names.index(blocked_subnet_name)
 
     proto_vector = NUM_SUBNETS * [0]


### PR DESCRIPTION
Fixes an issue whereby actions use subnet names to block/allow traffic, but the wrapper used IP addresses (actions appear to have used addresses in CC3). Both the wrapper and actions now use subnet names and the tests for `BlueEnterpriseWrapper` has been updated to reflect this change.

Closes #18. More end-to-end tests to follow in the near future (i.e. using the BlockTrafficZone action instead of manipulating the state directly).