### PR TITLE
Inserted Sleep action link. Modified evaluation.py file.

### DIFF
--- a/CybORG/Evaluation/evaluation.py
+++ b/CybORG/Evaluation/evaluation.py
@@ -109,7 +109,12 @@ def run_evaluation(submission, log_path, max_eps=100, write_to_file=True, seed=N
                 break
             r.append(mean(rew.values()))
             if write_to_file:
-                a.append(actions)
+                a.append(
+                    {
+                        agent_name: cyborg.get_last_action(agent_name)
+                        for agent_name in wrapped_cyborg.agents
+                    }       
+                )
                 o.append(
                     {
                         agent_name: observations[agent_name]

--- a/documentation/docs/pages/reference/agents/red_overview.md
+++ b/documentation/docs/pages/reference/agents/red_overview.md
@@ -15,7 +15,7 @@ Red agents have 10 possible actions that they can perform during an episode:
 | 6     | [Impact](../actions/red_actions/impact.md) | Impacts an operational service which is important to the mission. |
 | 7     | [DegradeServices](../actions/red_actions/degrade_services.md) | Degrades a service used by green in the mission. |
 | 8     | [Withdraw](../actions/red_actions/withdraw.md) | Withdraws a shell from a specific host. |
-| -     | [Sleep]() | The turn passes with no impact to the environment. |
+| -     | [Sleep](../../tutorials/03_Actions/A_Understanding_Actions/3_Sleep.md) | The turn passes with no impact to the environment. |
 
 Note: Sleep is not considered as an action for the FSM agents, and therefore has no index.
 


### PR DESCRIPTION
I inserted the sleep link into the documentations. This won't immediate solve the issue on the documents page, but will solve it whenever we redeploy the docs which isn't a major problem right now.

I also modified the evaluation file to output action names. Previously the outputted actions.txt file was outputting numbers, i.e., blue_agent_1: 53, where 53 corresponded to an action. The modification made outputs the name that corresponds to action 53, i.e., blue_agent_1: AllowTraffic.