### PR TITLE
Prevent Green Agents from executing Monitor

### DIFF
--- a/CybORG/Simulator/Scenarios/EnterpriseScenarioGenerator.py
+++ b/CybORG/Simulator/Scenarios/EnterpriseScenarioGenerator.py
@@ -734,7 +734,7 @@ class EnterpriseScenarioGenerator(ScenarioGenerator):
                     agent=None
                 )
                 agent_type = None
-                default_actions = (Monitor, {'session': 0, 'agent': agent_name})
+                default_actions = (Sleep, {})
                 if self.green_agent_class:
                     if self.green_agent_class == EnterpriseGreenAgent:
                         host_ip = hosts[hostname].interfaces[0].ip_address


### PR DESCRIPTION
Green agents mistakenly had Monitor set as a default action. This patch changes this to Sleep.

This also fixes a bug introduced by #28 where the simulation will crash whenever a green agent witnesses a process event.