### PR TITLE
Add search to documentation

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -198,6 +198,8 @@ plugins:
             separate_signature: true
             show_signature_annotations: true
             show_if_no_docstring: false
-
+  - search:
+      lang: ['en']  # Specify languages for stemming and stopwords.
+      separator: '[\s\-]+'  # Customize the word separator.
 
 copyright: Copyright &copy; 2023 TTCP CAGE


### PR DESCRIPTION
Having the ability to search the documentation would be very helpful. This PR makes use of the search plugin from `mkdocs-material`. 

More info can be found here: https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/ 