### PR TITLE
Make TernaryEnum values work in Boolean contexts

### DIFF
--- a/CybORG/Shared/Enums.py
+++ b/CybORG/Shared/Enums.py
@@ -24,6 +24,9 @@ class TernaryEnum(enum.Enum):
             other = TernaryEnum.parse_bool(other)
         return isinstance(other, TernaryEnum) and self.value == other.value
 
+    def __bool__(self):
+        return self.value == TernaryEnum.TRUE
+
 
 class OperatingSystemPatch(enum.Enum):
     UNKNOWN = enum.auto()


### PR DESCRIPTION
There are a few places where TernaryEnums are used in a Boolean context. Currently these are badly broken. This allows red agents to get a ton of Impact points incorrectly. If you meant for users of TernaryEnum to explicitly compare, `__bool__` should raise an exception.