### PR TITLE
Override unused state collection

### DIFF
--- a/CybORG/Shared/BlueRewardMachine.py
+++ b/CybORG/Shared/BlueRewardMachine.py
@@ -66,6 +66,13 @@ class BlueRewardMachine(RewardCalculator):
         
         return phase_rewards[cur_mission_phase]
 
+    def calculate_simulation_reward(self, env_controller):
+        # Current state is not used by the calculate_reward function
+        current_state = {}
+        action = env_controller.action
+        agent_observations = env_controller.observation
+        done = env_controller.done
+        return self.calculate_reward(current_state, action, agent_observations, done, env_controller.state)
 
     def calculate_reward(self, current_state: dict, action_dict: dict, agent_observations: dict, done: bool, state: State):
         """Calculate the cumulative reward based on the phase mapping.

--- a/CybORG/Shared/RewardCalculator.py
+++ b/CybORG/Shared/RewardCalculator.py
@@ -57,5 +57,8 @@ class RewardCalculator(CybORGLogger):
 
 
 class EmptyRewardCalculator(RewardCalculator):
+    def calculate_simulation_reward(self, env_controller):
+        return self.calculate_reward(None, None, None, None, None)
+
     def calculate_reward(self, current_state: dict, action: Action, agent_observations: dict, done: bool, state: object):
         return 0.


### PR DESCRIPTION
Both reward calculators (BlueRewardMachine and EmptyRewardCalculator) never use the `current_state` that is passed to the `calculate_reward` method. The collection of this state represents a major allocation of execution time during each timestep.

By skipping this collection, timestep execution is ~40-60% faster depending on actions and agents.

Fixes #45 